### PR TITLE
FIX ssh executable path

### DIFF
--- a/xontrib/ssh_agent.xsh
+++ b/xontrib/ssh_agent.xsh
@@ -1,12 +1,14 @@
 """Helper function to start SSH agent and add keys using ssh-add
 """
 import builtins
+from shutil import which
+
 from repassh import ssh
 
 __all__ = ()
 
 
-def sshc(binary="/bin/ssh", options={}):
+def sshc(binary=which('ssh'), options={}):
     def command(args, stdin=None, stdout=None, stderr=None):
         """Launch `repassh` with '[binary]' and the provided arguments
         """


### PR DESCRIPTION
Get the ssh path that can be in **/usr/bin** or **/bin**, depending on the distribution